### PR TITLE
Add support for HAXM on Mac OS X

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -33,7 +33,8 @@ elseif(LINUX)
     add_subdirectory(kvm)
 elseif(APPLE)
     add_subdirectory(haxm)
-    add_subdirectory(hvf)
+    # TODO: Add support for Hypervisor.Framework
+    #add_subdirectory(hvf)
 endif()
 
 add_subdirectory(virt86)

--- a/modules/core/src/vp/vp.cpp
+++ b/modules/core/src/vp/vp.cpp
@@ -571,7 +571,7 @@ void VirtualProcessor::HandleInterruptQueue() {
 }
 
 void VirtualProcessor::InjectPendingInterrupt() {
-    // If there no pending interrupts, leave
+    // If there are no pending interrupts, leave
     if (m_pendingInterrupts.size() == 0) {
         return;
     }

--- a/modules/haxm/src/darwin/haxm_sys_platform.cpp
+++ b/modules/haxm/src/darwin/haxm_sys_platform.cpp
@@ -1,0 +1,80 @@
+/*
+HAXM system-based platform implementation for Mac OS X.
+-------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2019 Ivan Roberto de Oliveira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include "haxm_sys_platform.hpp"
+
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+
+namespace virt86::haxm {
+
+HaxmPlatformSysImpl::HaxmPlatformSysImpl()
+    : m_fd(-1)
+{
+}
+
+HaxmPlatformSysImpl::~HaxmPlatformSysImpl() {
+    if (m_fd > 0) {
+        close(m_fd);
+        m_fd = -1;
+    }
+}
+
+PlatformInitStatus HaxmPlatformSysImpl::Initialize(hax_module_version *haxVer, hax_capabilityinfo *haxCaps) {
+    // Open the device
+    m_fd = open("/dev/HAX", O_RDWR);
+    if (m_fd < 0) {
+        return PlatformInitStatus::Unavailable;
+    }
+
+    // Retrieve version
+    int result = ioctl(m_fd, HAX_IOCTL_VERSION, haxVer);
+    if (result < 0) {
+        close(m_fd);
+        m_fd = -1;
+        return PlatformInitStatus::Failed;
+    }
+
+    // Retrieve capabilities
+    result = ioctl(m_fd, HAX_IOCTL_CAPABILITY, haxCaps);
+    if (result < 0) {
+        close(m_fd);
+        m_fd = -1;
+        return PlatformInitStatus::Failed;
+    }
+
+    return PlatformInitStatus::OK;
+}
+
+bool HaxmPlatformSysImpl::SetGlobalMemoryLimit(bool enabled, uint64_t limitMB) {
+    hax_set_memlimit memlimit;
+    memlimit.enable_memlimit = enabled;
+    memlimit.memory_limit = enabled ? limitMB : 0;
+    return ioctl(m_fd, HAX_IOCTL_SET_MEMLIMIT, &memlimit) == 0;
+}
+
+}
+

--- a/modules/haxm/src/darwin/haxm_sys_platform.hpp
+++ b/modules/haxm/src/darwin/haxm_sys_platform.hpp
@@ -1,0 +1,49 @@
+/*
+HAXM system-based platform implementation for Mac OS X.
+-------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2019 Ivan Roberto de Oliveira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#pragma once
+
+#include "virt86/platform/platform.hpp"
+
+#include "interface/hax_interface.hpp"
+
+namespace virt86::haxm {
+
+class HaxmPlatformSysImpl {
+public:
+    HaxmPlatformSysImpl();
+    ~HaxmPlatformSysImpl();
+
+    PlatformInitStatus Initialize(hax_module_version *haxVer, hax_capabilityinfo *haxCaps);
+
+    bool SetGlobalMemoryLimit(bool enabled, uint64_t limitMB);
+
+    const int FileDescriptor() const { return m_fd; }
+
+private:
+    int m_fd;
+};
+
+}

--- a/modules/haxm/src/darwin/haxm_sys_vm.cpp
+++ b/modules/haxm/src/darwin/haxm_sys_vm.cpp
@@ -1,0 +1,159 @@
+/*
+HAXM system-based virtual machine implementation for Mac OS X.
+-------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2019 Ivan Roberto de Oliveira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include "haxm_sys_vm.hpp"
+
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <string.h>
+
+namespace virt86::haxm {
+
+HaxmVirtualMachineSysImpl::HaxmVirtualMachineSysImpl(HaxmPlatformImpl& platformImpl)
+    : m_platformImpl(platformImpl)
+    , m_fd(-1)
+    , m_fdHAXM(platformImpl.m_sys->FileDescriptor())
+{
+}
+
+HaxmVirtualMachineSysImpl::~HaxmVirtualMachineSysImpl() {
+    Destroy();
+}
+
+bool HaxmVirtualMachineSysImpl::Initialize(const size_t numProcessors, uint32_t *out_vmID) {
+    // Ask HAXM to create a VM
+    uint32_t vmID;
+    int result = ioctl(m_fdHAXM, HAX_IOCTL_CREATE_VM, &vmID);
+    if (result == -1) {
+        return false;
+    }
+
+    // VM created successfully; open the object
+    char vmName[17];
+    sprintf(vmName, "/dev/hax_vm/vm%02d", vmID);
+    m_fd = open(vmName, O_RDWR);
+    if (m_fd == -1) {
+        *out_vmID = 0xFFFFFFFF;
+        return false;
+    }
+
+    *out_vmID = vmID;
+
+    return true;
+}
+
+void HaxmVirtualMachineSysImpl::Destroy() {
+    if (m_fd != -1) {
+        close(m_fd);
+        m_fd = -1;
+    }
+}
+
+bool HaxmVirtualMachineSysImpl::ReportQEMUVersion(hax_qemu_version& version) {
+    return ioctl(m_fd, HAX_VM_IOCTL_NOTIFY_QEMU_VERSION, &version) >= 0;
+}
+
+MemoryMappingStatus HaxmVirtualMachineSysImpl::MapGuestMemory(const uint64_t baseAddress, const uint32_t size, const MemoryFlags flags, void *memory) {
+    // Allocate memory
+    hax_alloc_ram_info memInfo;
+    memInfo.va = (uint64_t)memory;
+    memInfo.size = size;
+    int result = ioctl(m_fd, HAX_VM_IOCTL_ALLOC_RAM, &memInfo);
+    if (result < 0) {
+        return MemoryMappingStatus::AlreadyAllocated;
+    }
+
+    // Configure memory
+    hax_set_ram_info setMemInfo;
+    setMemInfo.pa_start = baseAddress;
+    setMemInfo.va = (uint64_t)memory;
+    setMemInfo.size = size;
+    setMemInfo.flags = BitmaskEnum(flags).AnyOf(MemoryFlags::Write) ? 0 : HAX_RAM_INFO_ROM;
+    result = ioctl(m_fd, HAX_VM_IOCTL_SET_RAM, &setMemInfo);
+    if (result < 0) {
+        return MemoryMappingStatus::Failed;
+    }
+
+    return MemoryMappingStatus::OK;
+}
+
+bool HaxmVirtualMachineSysImpl::UnmapGuestMemory(const uint64_t baseAddress, const uint32_t size) {
+    hax_set_ram_info setMemInfo;
+    setMemInfo.pa_start = baseAddress;
+    setMemInfo.va = 0;
+    setMemInfo.size = size;
+    setMemInfo.flags = HAX_RAM_INFO_INVALID;
+    return ioctl(m_fd, HAX_VM_IOCTL_SET_RAM, &setMemInfo) >= 0;
+}
+
+MemoryMappingStatus HaxmVirtualMachineSysImpl::MapGuestMemoryLarge(const uint64_t baseAddress, const uint64_t size, const MemoryFlags flags, void *memory) {
+    // Allocate memory
+    hax_ramblock_info memInfo;
+    memInfo.start_va = (uint64_t)memory;
+    memInfo.size = size;
+    memInfo.reserved = 0;
+    int result = ioctl(m_fd, HAX_VM_IOCTL_ADD_RAMBLOCK, &memInfo);
+    if (result < 0) {
+        return MemoryMappingStatus::AlreadyAllocated;
+    }
+
+    // Configure memory
+    hax_set_ram_info2 setMemInfo;
+    setMemInfo.pa_start = baseAddress;
+    setMemInfo.va = (uint64_t)memory;
+    setMemInfo.size = size;
+    setMemInfo.reserved1 = 0;
+    setMemInfo.reserved2 = 0;
+    setMemInfo.flags = BitmaskEnum(flags).AnyOf(MemoryFlags::Write) ? 0 : HAX_RAM_INFO_ROM;
+    result = ioctl(m_fd, HAX_VM_IOCTL_SET_RAM2, &setMemInfo);
+    if (result < 0) {
+        return MemoryMappingStatus::Failed;
+    }
+
+    return MemoryMappingStatus::OK;
+}
+
+bool HaxmVirtualMachineSysImpl::UnmapGuestMemoryLarge(const uint64_t baseAddress, const uint64_t size) {
+    hax_set_ram_info2 setMemInfo;
+    setMemInfo.pa_start = baseAddress;
+    setMemInfo.va = 0;
+    setMemInfo.size = size;
+    setMemInfo.reserved1 = 0;
+    setMemInfo.reserved2 = 0;
+    setMemInfo.flags = HAX_RAM_INFO_INVALID;
+    return ioctl(m_fd, HAX_VM_IOCTL_SET_RAM2, &setMemInfo) >= 0;
+}
+
+bool HaxmVirtualMachineSysImpl::SetGuestMemoryFlagsLarge(const uint64_t baseAddress, const uint64_t size, const MemoryFlags flags) {
+    hax_protect_ram_info protectInfo = { 0 };
+    protectInfo.pa_start = baseAddress;
+    protectInfo.size = size;
+    protectInfo.flags = static_cast<uint32_t>(flags);
+    return ioctl(m_fd, HAX_VM_IOCTL_PROTECT_RAM, &protectInfo) >= 0;
+}
+
+}
+

--- a/modules/haxm/src/darwin/haxm_sys_vm.hpp
+++ b/modules/haxm/src/darwin/haxm_sys_vm.hpp
@@ -1,0 +1,65 @@
+/*
+HAXM system-based virtual machine implementation for Mac OS X.
+-------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2019 Ivan Roberto de Oliveira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#pragma once
+
+#include "virt86/platform/platform.hpp"
+#include "haxm_platform_impl.hpp"
+#include "haxm_sys_platform.hpp"
+
+#include "interface/hax_interface.hpp"
+
+#include <sys/ioctl.h>
+
+namespace virt86::haxm {
+
+class HaxmVirtualMachineSysImpl {
+public:
+    HaxmVirtualMachineSysImpl(HaxmPlatformImpl& platformImpl);
+    ~HaxmVirtualMachineSysImpl();
+
+    bool Initialize(const size_t numProcessors, uint32_t *out_vmID);
+    void Destroy();
+
+    bool ReportQEMUVersion(hax_qemu_version& version);
+
+    MemoryMappingStatus MapGuestMemory(const uint64_t baseAddress, const uint32_t size, const MemoryFlags flags, void *memory);
+    bool UnmapGuestMemory(const uint64_t baseAddress, const uint32_t size);
+
+    MemoryMappingStatus MapGuestMemoryLarge(const uint64_t baseAddress, const uint64_t size, const MemoryFlags flags, void *memory);
+    bool UnmapGuestMemoryLarge(const uint64_t baseAddress, const uint64_t size);
+
+    bool SetGuestMemoryFlagsLarge(const uint64_t baseAddress, const uint64_t size, const MemoryFlags flags);
+
+    const int FileDescriptor() { return m_fd; }
+
+private:
+    HaxmPlatformImpl& m_platformImpl;
+
+    int m_fdHAXM;
+    int m_fd;
+};
+
+}

--- a/modules/haxm/src/darwin/haxm_sys_vp.cpp
+++ b/modules/haxm/src/darwin/haxm_sys_vp.cpp
@@ -1,0 +1,122 @@
+/*
+HAXM system-based virtual processor implementation for Mac OS X.
+-------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2019 Ivan Roberto de Oliveira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#include "haxm_sys_vm.hpp"
+#include "haxm_sys_vp.hpp"
+
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <string.h>
+
+namespace virt86::haxm {
+
+HaxmVirtualProcessorSysImpl::HaxmVirtualProcessorSysImpl(HaxmVirtualMachine& vm, HaxmVirtualMachineSysImpl& vmSys)
+    : m_vm(vm)
+    , m_vmSys(vmSys)
+    , m_fdVM(vmSys.FileDescriptor())
+    , m_fd(-1)
+{
+}
+
+HaxmVirtualProcessorSysImpl::~HaxmVirtualProcessorSysImpl() {
+    Destroy();
+}
+
+bool HaxmVirtualProcessorSysImpl::Initialize(uint32_t vcpuID, hax_tunnel** out_tunnel, void** out_ioTunnel) {
+    // Create virtual processor
+    int result = ioctl(m_fdVM, HAX_VM_IOCTL_VCPU_CREATE, &vcpuID);
+    if (result < 0) {
+        return false;
+    }
+
+    // Open virtual processor object
+    char vcpuName[21];
+    sprintf(vcpuName, "/dev/hax_vm%02d/vcpu%02d", m_vm.ID(), vcpuID);
+    m_fd = open(vcpuName, O_RDWR);
+    if (m_fd < 0) {
+        return false;
+    }
+
+    // Setup tunnel
+    hax_tunnel_info tunnelInfo;
+    result = ioctl(m_fd, HAX_VCPU_IOCTL_SETUP_TUNNEL, &tunnelInfo);
+    if (result < 0) {
+        close(m_fd);
+        m_fd = -1;
+        return false;
+    }
+
+    *out_tunnel = (hax_tunnel *)(intptr_t)tunnelInfo.va;
+    *out_ioTunnel = (void *)(intptr_t)tunnelInfo.io_va;
+
+    return true;
+}
+
+void HaxmVirtualProcessorSysImpl::Destroy() {
+    if (m_fd != -1) {
+        close(m_fd);
+        m_fd = -1;
+    }
+}
+
+bool HaxmVirtualProcessorSysImpl::Run() {
+    return ioctl(m_fd, HAX_VCPU_IOCTL_RUN) >= 0;
+}
+
+bool HaxmVirtualProcessorSysImpl::InjectInterrupt(uint8_t vector) {
+    return ioctl(m_fd, HAX_VCPU_IOCTL_INTERRUPT, (uint32_t)vector) >= 0;
+}
+
+bool HaxmVirtualProcessorSysImpl::GetRegisters(vcpu_state_t* registers) {
+    return ioctl(m_fd, HAX_VCPU_GET_REGS, registers) >= 0;
+}
+
+bool HaxmVirtualProcessorSysImpl::SetRegisters(vcpu_state_t* registers) {
+    return ioctl(m_fd, HAX_VCPU_SET_REGS, registers) >= 0;
+}
+
+bool HaxmVirtualProcessorSysImpl::GetFPURegisters(fx_layout* registers) {
+    return ioctl(m_fd, HAX_VCPU_IOCTL_GET_FPU, registers) >= 0;
+}
+
+bool HaxmVirtualProcessorSysImpl::SetFPURegisters(fx_layout* registers) {
+    return ioctl(m_fd, HAX_VCPU_IOCTL_SET_FPU, registers) >= 0;
+}
+
+bool HaxmVirtualProcessorSysImpl::GetMSRData(hax_msr_data* msrData) {
+    return ioctl(m_fd, HAX_VCPU_IOCTL_GET_MSRS, msrData) >= 0;
+}
+
+bool HaxmVirtualProcessorSysImpl::SetMSRData(hax_msr_data* msrData) {
+    return ioctl(m_fd, HAX_VCPU_IOCTL_SET_MSRS, msrData) >= 0;
+}
+
+bool HaxmVirtualProcessorSysImpl::SetDebug(hax_debug_t* debug) {
+    return ioctl(m_fd, HAX_IOCTL_VCPU_DEBUG, debug) >= 0;
+}
+
+}
+

--- a/modules/haxm/src/darwin/haxm_sys_vp.cpp
+++ b/modules/haxm/src/darwin/haxm_sys_vp.cpp
@@ -87,7 +87,8 @@ bool HaxmVirtualProcessorSysImpl::Run() {
 }
 
 bool HaxmVirtualProcessorSysImpl::InjectInterrupt(uint8_t vector) {
-    return ioctl(m_fd, HAX_VCPU_IOCTL_INTERRUPT, (uint32_t)vector) >= 0;
+    uint32_t vector32 = static_cast<uint32_t>(vector);
+    return ioctl(m_fd, HAX_VCPU_IOCTL_INTERRUPT, &vector32) >= 0;
 }
 
 bool HaxmVirtualProcessorSysImpl::GetRegisters(vcpu_state_t* registers) {

--- a/modules/haxm/src/darwin/haxm_sys_vp.hpp
+++ b/modules/haxm/src/darwin/haxm_sys_vp.hpp
@@ -1,0 +1,70 @@
+/*
+HAXM system-based virtual processor implementation for Mac OS X.
+-------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2019 Ivan Roberto de Oliveira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#pragma once
+
+#include "virt86/platform/platform.hpp"
+#include "haxm_vm.hpp"
+#include "haxm_platform_impl.hpp"
+#include "haxm_sys_platform.hpp"
+
+#include "interface/hax_interface.hpp"
+
+#include <sys/ioctl.h>
+
+namespace virt86::haxm {
+
+class HaxmVirtualProcessorSysImpl {
+public:
+    HaxmVirtualProcessorSysImpl(HaxmVirtualMachine& vm, HaxmVirtualMachineSysImpl& vmSys);
+    ~HaxmVirtualProcessorSysImpl();
+
+    bool Initialize(uint32_t vcpuID, hax_tunnel **out_tunnel, void **out_ioTunnel);
+    void Destroy();
+
+    bool Run();
+
+    bool InjectInterrupt(uint8_t vector);
+
+    bool GetRegisters(vcpu_state_t *registers);
+    bool SetRegisters(vcpu_state_t *registers);
+
+    bool GetFPURegisters(fx_layout *registers);
+    bool SetFPURegisters(fx_layout *registers);
+
+    bool GetMSRData(hax_msr_data *msrData);
+    bool SetMSRData(hax_msr_data *msrData);
+
+    bool SetDebug(hax_debug_t *debug);
+
+private:
+    HaxmVirtualMachine& m_vm;
+    HaxmVirtualMachineSysImpl& m_vmSys;
+
+    int m_fdVM;
+    int m_fd;
+};
+
+}

--- a/modules/haxm/src/linux/haxm_sys_vp.cpp
+++ b/modules/haxm/src/linux/haxm_sys_vp.cpp
@@ -87,7 +87,8 @@ bool HaxmVirtualProcessorSysImpl::Run() {
 }
 
 bool HaxmVirtualProcessorSysImpl::InjectInterrupt(uint8_t vector) {
-    return ioctl(m_fd, HAX_VCPU_IOCTL_INTERRUPT, (uint32_t)vector) >= 0;
+    uint32_t vector32 = static_cast<uint32_t>(vector);
+    return ioctl(m_fd, HAX_VCPU_IOCTL_INTERRUPT, &vector32) >= 0;
 }
 
 bool HaxmVirtualProcessorSysImpl::GetRegisters(vcpu_state_t* registers) {

--- a/modules/virt86/CMakeLists.txt
+++ b/modules/virt86/CMakeLists.txt
@@ -132,7 +132,8 @@ elseif(APPLE)
     else()
         find_package(virt86-hvf CONFIG REQUIRED)
     endif()
-    target_link_libraries(virt86 PUBLIC virt86::virt86-hvf)
+    # TODO: Add support for Hypervisor.Framework
+    #target_link_libraries(virt86 PUBLIC virt86::virt86-hvf)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
Fixes #4.

Additionally fixes an issue when injecting interrupts on Linux, and a small grammar error in `VirtualProcessor::InjectPendingInterrupt`.